### PR TITLE
🐛 화면 검정색으로 변하는 오류 수정

### DIFF
--- a/lib/ui/components/auth/sign_in_bottom_sheet.dart
+++ b/lib/ui/components/auth/sign_in_bottom_sheet.dart
@@ -43,7 +43,7 @@ class _SignInBottomSheetContentState extends State<_SignInBottomSheetContent> {
   void _checkAuthState() {
     if (_viewModel.isLoggedIn && mounted) {
       // 로그인 성공 시 바텀 시트 닫기
-      Navigator.of(context).pop();
+      Navigator.popUntil(context, (route) => route.isFirst);
     }
   }
 


### PR DESCRIPTION
# 📌 관련 이슈
- Closes #28 

## 📝 변경사항 개요
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 바텀 시트를 통해 로그인 한 후에 바텀 시트가 닫히면 검정 화면이 되던 오류를 수정했습니다.
- 앱 내비게이션 스택에서 첫 번째 라우트가 pop되지 않도록 했더니 고쳐졌어요.

## 📚 레이어별 변경사항

### 🎨 Feature Layer (UI/UX Layer)
<!-- UI/UX 계층의 변경사항을 설명해주세요 -->
<!-- 예: 화면 구성, 위젯, 사용자 인터랙션 등 -->
- `SignInBottomSheet._checkAuthState()` 메서드에서 `Navigation.of(...).pop()` 대신 `Navigation.popUntil(...)`을 사용하도록 변경했습니다.

---

### Self Check List
- [x] PR의 제목은 간단명료하게 작성했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 각 레이어별 변경사항을 명확히 설명했나요?
- [x] 레이어간 의존성 방향이 올바른가요? (Feature → Service → Repository)
- [ ] 적절한 테스트를 추가했나요?
- [ ] 불필요한 코드는 제거했나요?
- [x] 코드 스타일을 준수했나요?
- [ ] Breaking Change가 있다면 명시했나요?
- [ ] API 문서나 README 업데이트가 필요한가요?
