### PR TITLE
🚑 `/auth/sign` API 변경에 따른 수정

### DIFF
--- a/lib/repositories/backend/backend_repository.dart
+++ b/lib/repositories/backend/backend_repository.dart
@@ -48,10 +48,10 @@ class BackendRepository implements IBackendRepository {
   }
 
   @override
-  Future<User> postUserLogin(String googleIdToken) async {
+  Future<User> postUserLogin(String email, String? displayName) async {
     return _http.post(
       '/auth/sign',
-      {'id_token': googleIdToken},
+      {'email': email, if (displayName != null) 'username': displayName},
       User.fromJson,
       expectedStatus: 200,
     );

--- a/lib/repositories/backend/i_backend_repository.dart
+++ b/lib/repositories/backend/i_backend_repository.dart
@@ -4,7 +4,7 @@ import 'models/message.dart';
 
 abstract class IBackendRepository {
   String get baseUrl;
-  Future<User> postUserLogin(String googleIdToken);
+  Future<User> postUserLogin(String email, String? displayName);
 
   // Session related methods
   Future<List<Session>> getSessions();

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -64,7 +64,10 @@ class AuthService extends ChangeNotifier {
       }
       try {
         debugPrint('[GOOGLE ID TOKEN] ${googleUser.idToken}');
-        final user = await _backend.postUserLogin(googleUser.idToken);
+        final user = await _backend.postUserLogin(
+          googleUser.email,
+          googleUser.displayName,
+        );
         debugPrint('[JWT] ${user.accessToken}');
 
         final seobiUser = SeobiUser.fromGoogleAndBackendUser(


### PR DESCRIPTION
## 📝 변경사항 개요
<!-- 이번 PR에서 작업한 내용을 간단히 설명해주세요 -->
BE 서버의 `/auth/sign` 요청의 Body 형식이 변경되어 이에 맞춰 FE 앱을 수정했습니다. 참고하세요: https://github.com/wasseobi/seobi-backend/pull/107

## 📚 레이어별 변경사항

### 📦 Repository Layer (Data Layer)
<!-- 데이터 계층의 변경사항을 설명해주세요 -->
<!-- 예: API 통신, 로컬 저장소, 데이터베이스 관련 변경 등 -->
- `BackgroundRepository`: 요청 Body에 `id_token` 대신  `email`, `username` 포함

### ⚙️ Service Layer (Logic Layer)
<!-- 비즈니스 로직 계층의 변경사항을 설명해주세요 -->
<!-- 예: 상태 관리, 데이터 처리, 유틸리티 함수 등 -->
- `AuthService`: 요청에 이메일과 사용자 이름을 전달하도록 수정

---

### Self Check List
- [x] PR의 제목은 간단명료하게 작성했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 각 레이어별 변경사항을 명확히 설명했나요?
- [x] 레이어간 의존성 방향이 올바른가요? (Feature → Service → Repository)
- [ ] 적절한 테스트를 추가했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일을 준수했나요?
- [ ] Breaking Change가 있다면 명시했나요?
- [ ] API 문서나 README 업데이트가 필요한가요?
